### PR TITLE
Add new Frameshift plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ WORKDIR /opt/lib/perl/VEP/Plugins
 
 RUN wget https://raw.githubusercontent.com/Ensembl/VEP_plugins/release/95/Downstream.pm \
 https://raw.githubusercontent.com/griffithlab/pVACtools/master/tools/pvacseq/VEP_plugins/Wildtype.pm \
+https://raw.githubusercontent.com/griffithlab/pVACtools/master/tools/pvacseq/VEP_plugins/Frameshift.pm \
 https://raw.githubusercontent.com/Ensembl/VEP_plugins/release/95/CADD.pm \
 https://raw.githubusercontent.com/Ensembl/VEP_plugins/release/95/REVEL.pm \
 https://raw.githubusercontent.com/Ensembl/VEP_plugins/release/95/ExACpLI.pm \


### PR DESCRIPTION
This file is not yet available, since pVACtools 2.0 is not out yet (i.e. not merged into master). The file location corresponds to where Frameshift.pm will be located once pVACtools 2.0 is out. I will leave this PR in draft mode until this happens.