### PR TITLE
update to vep v105 and update pvactools plugin urls

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ensemblorg/ensembl-vep:release_101.0
+FROM ensemblorg/ensembl-vep:release_105.0
 LABEL maintainer="John Garza <johnegarza@wustl.edu>"
 LABEL description="Vep helper image"
 
@@ -19,18 +19,18 @@ RUN perl INSTALL.pl --NO_UPDATE
 RUN mkdir -p /opt/lib/perl/VEP/Plugins
 WORKDIR /opt/lib/perl/VEP/Plugins
 
-RUN wget https://raw.githubusercontent.com/Ensembl/VEP_plugins/release/95/Downstream.pm \
-https://raw.githubusercontent.com/griffithlab/pVACtools/master/tools/pvacseq/VEP_plugins/Wildtype.pm \
-https://raw.githubusercontent.com/griffithlab/pVACtools/master/tools/pvacseq/VEP_plugins/Frameshift.pm \
-https://raw.githubusercontent.com/Ensembl/VEP_plugins/release/95/CADD.pm \
-https://raw.githubusercontent.com/Ensembl/VEP_plugins/release/95/REVEL.pm \
-https://raw.githubusercontent.com/Ensembl/VEP_plugins/release/95/ExACpLI.pm \
-https://raw.githubusercontent.com/Ensembl/VEP_plugins/release/95/ExACpLI_values.txt \
-https://raw.githubusercontent.com/Ensembl/VEP_plugins/release/95/LoFtool.pm \
-https://raw.githubusercontent.com/Ensembl/VEP_plugins/release/95/LoFtool_scores.txt \
-https://raw.githubusercontent.com/Ensembl/VEP_plugins/release/95/SpliceRegion.pm \
-https://raw.githubusercontent.com/Ensembl/VEP_plugins/release/95/dbNSFP.pm \
-https://raw.githubusercontent.com/Ensembl/VEP_plugins/release/95/dbNSFP_replacement_logic
+RUN wget https://raw.githubusercontent.com/Ensembl/VEP_plugins/release/105/Downstream.pm \
+https://raw.githubusercontent.com/griffithlab/pVACtools/master/pvactools/tools/pvacseq/VEP_plugins/Wildtype.pm \
+https://raw.githubusercontent.com/griffithlab/pVACtools/master/pvactools/tools/pvacseq/VEP_plugins/Frameshift.pm \
+https://raw.githubusercontent.com/Ensembl/VEP_plugins/release/105/CADD.pm \
+https://raw.githubusercontent.com/Ensembl/VEP_plugins/release/105/REVEL.pm \
+https://raw.githubusercontent.com/Ensembl/VEP_plugins/release/105/ExACpLI.pm \
+https://raw.githubusercontent.com/Ensembl/VEP_plugins/release/105/ExACpLI_values.txt \
+https://raw.githubusercontent.com/Ensembl/VEP_plugins/release/105/LoFtool.pm \
+https://raw.githubusercontent.com/Ensembl/VEP_plugins/release/105/LoFtool_scores.txt \
+https://raw.githubusercontent.com/Ensembl/VEP_plugins/release/105/SpliceRegion.pm \
+https://raw.githubusercontent.com/Ensembl/VEP_plugins/release/105/dbNSFP.pm \
+https://raw.githubusercontent.com/Ensembl/VEP_plugins/release/105/dbNSFP_replacement_logic
 
 COPY vcf_check.pl /usr/bin/vcf_check.pl
 


### PR DESCRIPTION
I tested all the plugin URLs to ensure they are correct for the latest version of vep and pvactools. Due to slight restructuring of the pvactools repo, those raw URLs had to be updated.  I also confirmed that `105.0` is the correct name for the latest ensembl base docker. 